### PR TITLE
Option to omit files for inlineEverything

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Default: true
 
 Similar to `script` and `link`, callback gets filename as arg and can return `true` (proceed with default encoding of the image), `false` (abort the grunt task) or String, which will be used to replace value of image's `src` attribute.
 
+### filesIgnore
+Type: `Array of String`
+Default: []
+
+Add files that you do not want to inline (for example, if you want have 3 stylesheets in your html file but only want to inline 2 of them).
+
+Add all files here that you do not want inlined, including links, images, and scripts.
+
+##### For example:
+If you do not want to inline the file "assets/fonts.css", you would do
+
+`filesIgnore: ['assets/fonts.css']`
+
 
 ### Usage Example
 

--- a/tasks/inlineEverything.js
+++ b/tasks/inlineEverything.js
@@ -55,6 +55,11 @@ module.exports = function(grunt) {
 					fileName = doPartialMagicToFileName(fileName, partialPath);
 				}
 
+				// if we want to omit this file, we can just return the original link tag
+				if (options.filesIgnore && options.filesIgnore.includes(fileName)) {
+					return full;
+				}
+
 				sheets.push(fileName);
 
 				if(options.tags.link && typeof options.tags.link === 'function') {
@@ -170,6 +175,11 @@ module.exports = function(grunt) {
 					fileName = doPartialMagicToFileName(fileName, partialPath);
 				}
 
+				// if we want to omit this file, we can just return the original script tag
+				if (options.filesIgnore && options.filesIgnore.includes(fileName)) {
+					return full;
+				}
+
 				fileName = path.join(options.relativeTo, fileName);
 				if(typeof options.tags.script === 'function') {
 					fileName = options.tags.script(fileName);
@@ -209,6 +219,11 @@ module.exports = function(grunt) {
 				// magic replacements for partials
 				if(partialPath) {
 					fileName = doPartialMagicToFileName(fileName, partialPath);
+				}
+
+				// if we want to omit this file, we can just return the original image tag
+				if (options.filesIgnore && options.filesIgnore.includes(fileName)) {
+					return full;
 				}
 
 				// optional preEncodeCallback callback


### PR DESCRIPTION
This feature is so users are able to omit certain files from being inlined (ex. if a user only wanted 2/3 of the stylesheets inlined, and the last stylesheet to remain a link tag in the html).

I added an option in inlineEverything called `filesIgnore` which will hold an array of file names that the user does not want to inline. The array will hold file names for all images/links/scripts.

Then in the inlineLinkTags/inlineScriptTags/inlineImageTags functions, I added a check whether the file name is included in options.filesIgnore. 